### PR TITLE
Switch to PUT to be more semantically correct

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,10 @@
 
 [![Build Status](https://travis-ci.org/tomelliff/s3-web-service-proxy.svg?branch=master)](https://travis-ci.org/tomelliff/s3-web-service-proxy) [![Coverage Status](https://coveralls.io/repos/github/tomelliff/s3-web-service-proxy/badge.svg?branch=master)](https://coveralls.io/github/tomelliff/s3-web-service-proxy?branch=master) [![Codacy Badge](https://api.codacy.com/project/badge/Grade/07424b22b069429c93d0ae6c696a66bb)](https://www.codacy.com/app/tomelliff/s3-web-service-proxy?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=tomelliff/s3-web-service-proxy&amp;utm_campaign=Badge_Grade)
 
-A basic Lambda function to proxy through the event to a POSTable endpoint.
+A basic Lambda function to proxy through the event to a PUT-able endpoint.
 
 Specifically aimed at notifying an application of an S3 PUT event, making the process more event driven than just polling the S3 bucket.
 
 TODO:
-- Change to PUT to be more semantically correct (?)
 - Cloudformation to deploy things
   - Launch stack button

--- a/s3_web_service_proxy.py
+++ b/s3_web_service_proxy.py
@@ -19,8 +19,23 @@ def handler(event, context):
     return response
 
 
+class MethodRequest(urllib2.Request):
+    def __init__(self, *args, **kwargs):
+        if 'method' in kwargs:
+            self._method = kwargs['method']
+            del kwargs['method']
+        else:
+            self._method = None
+        return urllib2.Request.__init__(self, *args, **kwargs)
+
+    def get_method(self, *args, **kwargs):
+        if self._method is not None:
+            return self._method
+        return urllib2.Request.get_method(self, *args, **kwargs)
+
+
 def proxy_event_to_web_service(event, endpoint_url):
-    request = urllib2.Request(endpoint_url)
+    request = MethodRequest(endpoint_url, method='PUT')
     request.add_header('Content-Type', 'application/json')
 
     response = urllib2.urlopen(request, event)

--- a/test_s3_web_service_proxy.py
+++ b/test_s3_web_service_proxy.py
@@ -66,9 +66,23 @@ class TestHandler(unittest.TestCase):
                          self.expected_response)
 
 
+class TestMethodRequest(unittest.TestCase):
+    def test_no_method_specified_uses_get(self):
+        self.assertEqual(
+            s3_web_service_proxy.MethodRequest(
+                'http://example.com').get_method(),
+            'GET')
+
+    def test_method_overridden(self):
+        self.assertEqual(
+            s3_web_service_proxy.MethodRequest(
+                'http://example.com', method='PUT').get_method(),
+            'PUT')
+
+
 class TestHttpCall(unittest.TestCase):
-    def test_proxy_posts_event(self):
+    def test_proxy_puts_event(self):
         self.assertEquals(json.loads(
             s3_web_service_proxy.proxy_event_to_web_service(
-                'event', 'http://httpbin.org/post'))['data'],
+                'event', 'http://httpbin.org/put'))['data'],
             'event')


### PR DESCRIPTION
Technically this call should be idempotent as it is telling a web service that an event has happened so a PUT is more appropriate.
However this does add to a bit of extra growth in code as urllib2 will only normally GET/POST.
The alternative would be to use requests but this adds a dependency to the project which adds more complication in building and deploying a package for AWS Lambda.

Method overriding for urllib2 was found at http://stackoverflow.com/questions/21243834/doing-put-using-python-urllib2/31839324#31839324